### PR TITLE
Allow separated service definition interfaces.

### DIFF
--- a/src/MagicOnion/Client/DynamicClientBuilder.cs
+++ b/src/MagicOnion/Client/DynamicClientBuilder.cs
@@ -58,7 +58,9 @@ namespace MagicOnion.Client
         static MethodDefinition[] SearchDefinitions(Type interfaceType)
         {
             return interfaceType
-                .GetMethods()
+                .GetInterfaces()
+                .Concat(new []{ interfaceType })
+                .SelectMany(x => x.GetMethods())
                 .Where(x =>
                 {
                     var methodName = x.Name;
@@ -130,7 +132,7 @@ namespace MagicOnion.Client
                     il.Emit(OpCodes.Ldtoken, resolverType);
                     il.Emit(OpCodes.Call, getTypeFromHandle);
                     il.Emit(OpCodes.Ldstr, def.Path);
-                    il.Emit(OpCodes.Ldtoken, interfaceType);
+                    il.Emit(OpCodes.Ldtoken, def.MethodInfo.DeclaringType);
                     il.Emit(OpCodes.Call, getTypeFromHandle);
                     il.Emit(OpCodes.Ldstr, def.MethodInfo.Name);
                     il.Emit(OpCodes.Call, typeof(Type).GetMethod("GetMethod", new[] { typeof(string) }));

--- a/tests/MagicOnion.Tests/MagicOnion.Tests.csproj
+++ b/tests/MagicOnion.Tests/MagicOnion.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="ChainingAssertion.xUnit.cs" />
     <Compile Include="ClientConfigTest.cs" />
     <Compile Include="FilterTest.cs" />
+    <Compile Include="PartialDefinitionTest.cs" />
     <Compile Include="ReturnStatusTest.cs" />
     <Compile Include="ServerErrorTest.cs" />
     <Compile Include="SimpleTest.cs" />

--- a/tests/MagicOnion.Tests/PartialDefinitionTest.cs
+++ b/tests/MagicOnion.Tests/PartialDefinitionTest.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Threading.Tasks;
+using Grpc.Core;
+using MagicOnion.Client;
+using MagicOnion.Server;
+using Xunit;
+
+
+
+namespace MagicOnion.Tests
+{
+    public interface IPartialDefinition : IService<IPartialDefinition>, IPartialDefinition2
+    {
+        UnaryResult<int> Unary1(int x, int y);
+    }
+
+
+    public interface IPartialDefinition2
+    {
+        UnaryResult<int> Unary2();
+    }
+
+
+    public class CombinedDefinition : ServiceBase<IPartialDefinition>, IPartialDefinition2
+    {
+        public UnaryResult<int> Unary1(int x, int y)
+            => this.UnaryResult(x + y);
+
+        public UnaryResult<int> Unary2()
+            => this.UnaryResult(100);
+    }
+
+
+    public class PartialDefinitionTest : IClassFixture<ServerFixture>, IDisposable
+    {
+        Channel channel;
+
+        public PartialDefinitionTest(ServerFixture server)
+        {
+            this.channel = new Channel(server.ServerPort.Host, server.ServerPort.Port, ChannelCredentials.Insecure);
+        }
+
+        public void Dispose()
+        {
+            channel.ShutdownAsync().Wait();
+        }
+
+        [Fact]
+        public async Task Unary1()
+        {
+            var client = MagicOnionClient.Create<IPartialDefinition>(channel);
+            var r = await client.Unary1(10, 20);
+            r.Is(30);
+        }
+
+        [Fact]
+        public async Task Unary2()
+        {
+            var client = MagicOnionClient.Create<IPartialDefinition>(channel);
+            var r = await client.Unary2();
+            r.Is(100);
+        }
+    }
+}


### PR DESCRIPTION
Now, MagicOnion doesn't allow separated service definition like following.

```cs
//--- Separated service definition.
public interface IFoo : IService<IFoo>, IBar
{
    UnaryResult<object> Hoge();
}

public interface IBar
{
    Task<ServerStreamingResult<int>> Fuga();
}

//--- Combined service implementation.
public class Foo : ServiceBase<IFoo>
{
    public UnaryResult<object> Hoge(){}
    public Task<ServerStreamingResult<int>> Fuga(){}
}
```

This pull request removes that constraint.