### PR TITLE
Suppress warning

### DIFF
--- a/src/MagicOnion/MagicOnion.csproj
+++ b/src/MagicOnion/MagicOnion.csproj
@@ -131,9 +131,7 @@
             <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
         </PropertyGroup>
         <Error Condition="!Exists('$(SolutionDir)packages\Grpc.Core.1.2.0\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Grpc.Core.1.2.0\build\net45\Grpc.Core.targets'))" />
-        <Error Condition="!Exists('$(SolutionDir)packages\Grpc.Core.1.2.0\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Grpc.Core.1.2.0\build\net45\Grpc.Core.targets'))" />
     </Target>
-    <Import Project="$(SolutionDir)packages\Grpc.Core.1.2.0\build\net45\Grpc.Core.targets" Condition="Exists('$(SolutionDir)packages\Grpc.Core.1.2.0\build\net45\Grpc.Core.targets')" />
     <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
After gRPC v1.2 is supported, warnings have been occured because of duplicated tag in MagicOnion.csproj. This pull-request suppresses these warnings.