### PR TITLE
Broadcast for IE<StreamingContextRepository>

### DIFF
--- a/src/MagicOnion/Server/StreamingContextGroup.cs
+++ b/src/MagicOnion/Server/StreamingContextGroup.cs
@@ -214,6 +214,13 @@ namespace MagicOnion.Server
             return repositories.Where(x => !set.Equals(x.Key)).Select(x => x.Value);
         }
 
+        public Task BroadcastToAsync<TResponse>(Func<TStreamingService, Func<Task<ServerStreamingResult<TResponse>>>> methodSelector, TResponse value, IEnumerable<TKey> includeKeys, bool parallel = true, bool ignoreError = true)
+        {
+            return Get(includeKeys)
+                .Select(x => x.Item2)
+                .BroadcastAsync(methodSelector, value, parallel, ignoreError);
+        }
+
         public Task BroadcastAllAsync<TResponse>(Func<TStreamingService, Func<Task<ServerStreamingResult<TResponse>>>> methodSelector, TResponse value, bool parallel = true, bool ignoreError = true)
         {
             return All()

--- a/src/MagicOnion/Server/StreamingContextGroup.cs
+++ b/src/MagicOnion/Server/StreamingContextGroup.cs
@@ -71,6 +71,16 @@ namespace MagicOnion.Server
             return repositories.TryGetValue(key, out v) ? v : null;
         }
 
+        public IEnumerable<StreamingContextRepository<TStreamingService>> Get(params TKey[] keys)
+        {
+            return keys.Select(x => this.Get(x)).Where(x => x != null);
+        }
+
+        public IEnumerable<StreamingContextRepository<TStreamingService>> Get(IEnumerable<TKey> keys)
+        {
+            return keys.Select(x => this.Get(x)).Where(x => x != null);
+        }
+
         public IEnumerable<StreamingContextRepository<TStreamingService>> All()
         {
             return repositories.Values;
@@ -94,7 +104,7 @@ namespace MagicOnion.Server
 
         public Task BroadcastToAsync<TResponse>(Func<TStreamingService, Func<Task<ServerStreamingResult<TResponse>>>> methodSelector, TResponse value, IEnumerable<TKey> includeKeys, bool parallel = true, bool ignoreError = true)
         {
-            return includeKeys.Select(x => this.Get(x)).Where(x => x != null).BroadcastAsync(methodSelector, value, parallel, ignoreError);
+            return Get(includeKeys).BroadcastAsync(methodSelector, value, parallel, ignoreError);
         }
 
         public Task BroadcastAllAsync<TResponse>(Func<TStreamingService, Func<Task<ServerStreamingResult<TResponse>>>> methodSelector, TResponse value, bool parallel = true, bool ignoreError = true)
@@ -170,6 +180,16 @@ namespace MagicOnion.Server
         {
             Tuple<TValue, StreamingContextRepository<TStreamingService>> v;
             return repositories.TryGetValue(key, out v) ? v : null;
+        }
+
+        public IEnumerable<Tuple<TValue, StreamingContextRepository<TStreamingService>>> Get(params TKey[] keys)
+        {
+            return keys.Select(x => this.Get(x)).Where(x => x != null);
+        }
+
+        public IEnumerable<Tuple<TValue, StreamingContextRepository<TStreamingService>>> Get(IEnumerable<TKey> keys)
+        {
+            return keys.Select(x => this.Get(x)).Where(x => x != null);
         }
 
         public TValue GetValue(TKey key)


### PR DESCRIPTION
Currently `SteamingContextGroup` class has some `StreamingContextRepository` collection getter methods (e.g. `AllExcept`). However MagicOnion doesn't support broadcasting methods for `IE<StreamingContextRepository>`. This pull-request supports them :)