### PR TITLE
Faster broadcast

### DIFF
--- a/sandbox/Sandbox.ConsoleServer/Services/ChatRoomService.cs
+++ b/sandbox/Sandbox.ConsoleServer/Services/ChatRoomService.cs
@@ -43,17 +43,17 @@ namespace Sandbox.ConsoleServer.Services
 
         public Task BroadcastJoinAsync(RoomMember joinMember)
         {
-            return this.group.BroadcastAllAsync(x => x.OnJoin, joinMember);
+            return this.group.BroadcastAllAsync(x => nameof(x.OnJoin), joinMember);
         }
 
         public Task BroadcastLeaveAsync(RoomMember leaveMember)
         {
-            return this.group.BroadcastAllAsync(x => x.OnLeave, leaveMember);
+            return this.group.BroadcastAllAsync(x => nameof(x.OnLeave), leaveMember);
         }
 
         public Task BroadcastMessageAsync(RoomMember sendMember, string message)
         {
-            return this.group.BroadcastAllAsync(x => x.OnMessageReceived, new ChatMessage { Sender = sendMember, Message = message });
+            return this.group.BroadcastAllAsync(x => nameof(x.OnMessageReceived), new ChatMessage { Sender = sendMember, Message = message });
         }
 
         public ChatRoomResponse ToChatRoomResponse()

--- a/src/MagicOnion/Server/StreamingContextGroup.cs
+++ b/src/MagicOnion/Server/StreamingContextGroup.cs
@@ -92,7 +92,7 @@ namespace MagicOnion.Server
             return repositories.Where(x => !set.Equals(x.Key)).Select(x => x.Value);
         }
 
-        public async Task BroadcastToAsync<TResponse>(Func<TStreamingService, Func<Task<ServerStreamingResult<TResponse>>>> methodSelector, TResponse value, IEnumerable<TKey> includeKeys, bool parallel = true, bool ignoreError = true)
+        public async Task BroadcastToAsync<TResponse>(Func<TStreamingService, string> methodSelector, TResponse value, IEnumerable<TKey> includeKeys, bool parallel = true, bool ignoreError = true)
         {
             if (parallel)
             {
@@ -110,7 +110,7 @@ namespace MagicOnion.Server
             }
         }
 
-        public async Task BroadcastAllAsync<TResponse>(Func<TStreamingService, Func<Task<ServerStreamingResult<TResponse>>>> methodSelector, TResponse value, bool parallel = true, bool ignoreError = true)
+        public async Task BroadcastAllAsync<TResponse>(Func<TStreamingService, string> methodSelector, TResponse value, bool parallel = true, bool ignoreError = true)
         {
             if (parallel)
             {
@@ -128,7 +128,7 @@ namespace MagicOnion.Server
             }
         }
 
-        public async Task BroadcastAllExceptAsync<TResponse>(Func<TStreamingService, Func<Task<ServerStreamingResult<TResponse>>>> methodSelector, TResponse value, TKey exceptKey, bool parallel = true, bool ignoreError = true)
+        public async Task BroadcastAllExceptAsync<TResponse>(Func<TStreamingService, string> methodSelector, TResponse value, TKey exceptKey, bool parallel = true, bool ignoreError = true)
         {
             if (parallel)
             {
@@ -146,7 +146,7 @@ namespace MagicOnion.Server
             }
         }
 
-        public async Task BroadcastAllExceptAsync<TResponse>(Func<TStreamingService, Func<Task<ServerStreamingResult<TResponse>>>> methodSelector, TResponse value, IEnumerable<TKey> exceptKeys, bool parallel = true, bool ignoreError = true)
+        public async Task BroadcastAllExceptAsync<TResponse>(Func<TStreamingService, string> methodSelector, TResponse value, IEnumerable<TKey> exceptKeys, bool parallel = true, bool ignoreError = true)
         {
             if (parallel)
             {
@@ -265,7 +265,7 @@ namespace MagicOnion.Server
             return repositories.Where(x => !set.Equals(x.Key)).Select(x => x.Value);
         }
 
-        public async Task BroadcastAllAsync<TResponse>(Func<TStreamingService, Func<Task<ServerStreamingResult<TResponse>>>> methodSelector, TResponse value, bool parallel = true, bool ignoreError = true)
+        public async Task BroadcastAllAsync<TResponse>(Func<TStreamingService, string> methodSelector, TResponse value, bool parallel = true, bool ignoreError = true)
         {
             if (parallel)
             {
@@ -283,7 +283,7 @@ namespace MagicOnion.Server
             }
         }
 
-        public async Task BroadcastAllExceptAsync<TResponse>(Func<TStreamingService, Func<Task<ServerStreamingResult<TResponse>>>> methodSelector, TResponse value, TKey exceptKey, bool parallel = true, bool ignoreError = true)
+        public async Task BroadcastAllExceptAsync<TResponse>(Func<TStreamingService, string> methodSelector, TResponse value, TKey exceptKey, bool parallel = true, bool ignoreError = true)
         {
             if (parallel)
             {
@@ -301,7 +301,7 @@ namespace MagicOnion.Server
             }
         }
 
-        public async Task BroadcastAllExceptAsync<TResponse>(Func<TStreamingService, Func<Task<ServerStreamingResult<TResponse>>>> methodSelector, TResponse value, TKey[] exceptKeys, bool parallel = true, bool ignoreError = true)
+        public async Task BroadcastAllExceptAsync<TResponse>(Func<TStreamingService, string> methodSelector, TResponse value, TKey[] exceptKeys, bool parallel = true, bool ignoreError = true)
         {
             if (parallel)
             {

--- a/tests/MagicOnion.Tests/StreamingContextGroupTest.cs
+++ b/tests/MagicOnion.Tests/StreamingContextGroupTest.cs
@@ -40,7 +40,7 @@ namespace MagicOnion.Tests
 
         public async Task<UnaryResult<bool>> SendMessage(string message)
         {
-            await group.BroadcastAllAsync(x => x.ReceiveMessages, message, ignoreError: false);
+            await group.BroadcastAllAsync(x => nameof(x.ReceiveMessages), message, ignoreError: false);
             return UnaryResult(true);
         }
 

--- a/tests/MagicOnion.Tests/StreamingContextRepositoryTest.cs
+++ b/tests/MagicOnion.Tests/StreamingContextRepositoryTest.cs
@@ -40,7 +40,7 @@ namespace MagicOnion.Tests
 
         public async Task<UnaryResult<bool>> SendMessage(string message)
         {
-            await cache.WriteAsync(x => x.ReceiveMessages, message);
+            await cache.WriteAsync(x => nameof(x.ReceiveMessages), message);
             return UnaryResult(true);
         }
 


### PR DESCRIPTION
# Motivation

Currently, MagicOnion caches `StreamingContextInfo` which is for broadcast using `MethodInfo` as key. `MethodInfo` is got from `Delegate.Method` property which 1st read is slow. Because `Delegate.Method` caches `MethodInfo` internally, 2nd read is fast. However `StreamingContextGroup.BroadcastXxxAsync` is almost called only one time at a Unary call. In other words `Delegate.Method` internally cache almost never works, so broadcast is always slow.


# Solution

This pull-request improves above problem using `string` key instead of `MethodInfo` key. This is the smallest possible change.


# Impact

About **x8 faster** than using `MethodInfo` key.