### PR TITLE
Unreachable code detected on iOS.

### DIFF
--- a/src/MagicOnion.Client.Unity/Assets/Scripts/gRPC/Core/Internal/NativeExtension.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/gRPC/Core/Internal/NativeExtension.cs
@@ -179,8 +179,8 @@ namespace Grpc.Core.Internal
         private static string GetNativeLibraryFilename()
         {
 #if UNITY_IOS || UNITY_TVOS || UNITY_WEBGL
-		return "__Internal";
-#endif
+            return "__Internal";
+#else
 
             string architecture = GetArchitectureString();
             if (PlatformApis.IsWindows)
@@ -196,6 +196,7 @@ namespace Grpc.Core.Internal
                 return string.Format("libgrpc_csharp_ext.{0}.dylib", architecture);
             }
             throw new InvalidOperationException("Unsupported platform.");
+#endif
         }
     }
 }


### PR DESCRIPTION
When I switch the platform to iOS in UnityEditor, unreachable code is detected (CS0162).

`Assets/Scripts/gRPC/Core/Internal/NativeExtension.cs(185,13): warning CS0162: Unreachable code detected`

To avoid this warning, I improved the code.