### PR TITLE
Fix UnityEditor hang up problem by stopping automatic compilation of scripts.

### DIFF
--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/Unity/CompileStopperDuringPlayMode.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/Unity/CompileStopperDuringPlayMode.cs
@@ -1,5 +1,4 @@
 ﻿#if UNITY_EDITOR
-using UnityEngine;
 using UnityEditor;
 
 namespace MagicOnion
@@ -23,7 +22,6 @@ namespace MagicOnion
                 EditorApplication.LockReloadAssemblies();
                 EditorApplication.playmodeStateChanged += PlayModeChanged;
                 isStopped = true;
-                Debug.Log("Stop Compiling the scripts");
             }
         }
 
@@ -35,7 +33,6 @@ namespace MagicOnion
             EditorApplication.UnlockReloadAssemblies();
             EditorApplication.playmodeStateChanged -= PlayModeChanged;
             isStopped = false;
-            Debug.Log("Start Compiling the scripts");
         }
     }
 }

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/Unity/CompileStopperDuringPlayMode.cs
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/Unity/CompileStopperDuringPlayMode.cs
@@ -1,0 +1,42 @@
+﻿#if UNITY_EDITOR
+using UnityEngine;
+using UnityEditor;
+
+namespace MagicOnion
+{
+    [InitializeOnLoad]
+    public class CompileStopperDuringPlayMode
+    {
+        static bool isStopped = false;
+
+        static CompileStopperDuringPlayMode()
+        {
+            EditorApplication.update += OnEditorUpdate;
+        }
+
+        static void OnEditorUpdate()
+        {
+            if (!isStopped
+                && EditorApplication.isCompiling
+                && EditorApplication.isPlaying)
+            {
+                EditorApplication.LockReloadAssemblies();
+                EditorApplication.playmodeStateChanged += PlayModeChanged;
+                isStopped = true;
+                Debug.Log("Stop Compiling the scripts");
+            }
+        }
+
+        static void PlayModeChanged()
+        {
+            if (EditorApplication.isPlaying)
+                return;
+
+            EditorApplication.UnlockReloadAssemblies();
+            EditorApplication.playmodeStateChanged -= PlayModeChanged;
+            isStopped = false;
+            Debug.Log("Start Compiling the scripts");
+        }
+    }
+}
+#endif

--- a/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/Unity/CompileStopperDuringPlayMode.cs.meta
+++ b/src/MagicOnion.Client.Unity/Assets/Scripts/MagicOnion/Unity/CompileStopperDuringPlayMode.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f09ae5a1c2ff04a1186ae8f9e0021612
+timeCreated: 1505189122
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Environment
- Unity 5.6.3p2 on Mac
- Unity 5.6.3p2 on Windows

I noticed that there was no response from the UnityEditor application when editing the script file during play mode.
This script prevents UnityEditor from compiling during play mode.
UnityEditor no longer hangs up after implementing it.

I am not sure whether the script should be included in MagicOnion or not. I think it needs to be explained in README.md.
Thanks!
